### PR TITLE
Renaming PACMAN_CREDENTIAL to PACMAN_AUTH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,27 +5,41 @@
 HAS_GODOC := $(shell command -v godoc;)
 HAS_GOLANGCI := $(shell command -v golangci-lint;)
 
-default: ci
+define PRINT_HELP_PYSCRIPT
+import re, sys
 
-lint:
+for line in sys.stdin:
+	match = re.match(r'^([0-9a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+help:  ## prints (this) help message
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+default: help
+
+lint:  ## lint the code
 ifndef HAS_GOLANGCI
 	$(error You must install github.com/golangci/golangci-lint)
 endif
 	@golangci-lint run -v -c .golangci.yml && echo "Lint OK"
 
-test:
+test:  ## run tests
 	@go test -timeout 30s -short -v -race -cover -coverprofile=coverage.out ./...
 
-coverage:
+coverage:  ## generate coverage report
 	@go tool cover -func=coverage.out
 
-doc:
+doc:  ## start godoc server
 ifndef HAS_GODOC
 	$(error You must install godoc, run "go get golang.org/x/tools/cmd/godoc")
 endif
-	@echo "Open localhost:6060/pkg/github.com/saucelabs/pacman/ in your browser\n"
+	@echo "Open http://localhost:6060/pkg/github.com/saucelabs/pacman/ in your browser\n"
 	@godoc -http :6060
 
-ci: lint test coverage
+ci: lint test coverage  ## lint + test + coverage
 
-.PHONY: lint test coverage doc ci
+.PHONY: lint test coverage doc ci help

--- a/parser.go
+++ b/parser.go
@@ -256,7 +256,7 @@ func fromURL(uri string, proxiesURIs ...string) (*Parser, error) {
 		req.SetBasicAuth(u.User.Username(), password)
 	}
 
-	if err := setCredentialFromEnvVar("PACMAN_CREDENTIAL", u, req); err != nil {
+	if err := setCredentialFromEnvVar("PACMAN_AUTH", u, req); err != nil {
 		return nil, err
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -246,8 +246,8 @@ func TestParser_New_fromweb(t *testing.T) {
 
 	u.User = url.UserPassword("user1", "pass1")
 
-	os.Setenv("PACMAN_CREDENTIAL", "user:pass")
-	defer os.Unsetenv("PACMAN_CREDENTIAL")
+	os.Setenv("PACMAN_AUTH", "user:pass")
+	defer os.Unsetenv("PACMAN_AUTH")
 
 	pacFromWeb, err := pacman.New(u.String())
 	if err != nil {


### PR DESCRIPTION
Renaming PACMAN_CREDENTIAL to PACMAN_AUTH to maintain the same naming convention as in [forwarder](https://github.com/saucelabs/forwarder)